### PR TITLE
Add component tests

### DIFF
--- a/test/component_test.go
+++ b/test/component_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -73,6 +74,10 @@ func (s *ComponentSuite) TestBasic() {
 	assert.NotNil(s.T(), metadata.Values)
 	assert.Equal(s.T(), metadata.Version, "0.8.3")
 
+	// Deploy second time to create ClusterSecretStore resource
+	options, _ = s.DeployAtmosComponent(s.T(), component, stack, &inputs)
+	assert.NotNil(s.T(), options)
+
 	config, err := awsHelper.NewK8SClientConfig(cluster)
 	assert.NoError(s.T(), err)
 	assert.NotNil(s.T(), config)
@@ -121,8 +126,7 @@ func (s *ComponentSuite) TestBasic() {
 		},
 	}
 
-
-	factory := dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 0)
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, time.Minute, corev1.NamespaceAll, nil)
 	informer := factory.ForResource(externalSecretGVR).Informer()
 
 	stopChannel := make(chan struct{})
@@ -136,6 +140,7 @@ func (s *ComponentSuite) TestBasic() {
 				return
 			}
 
+			// Ensure we are checking the status of the correct object
 			conditions, found, err := unstructured.NestedSlice(externalSecret.Object, "status", "conditions")
 
 			if err != nil || !found {
@@ -170,7 +175,7 @@ func (s *ComponentSuite) TestBasic() {
 		case <-stopChannel:
 			msg := "ExternalSecret is ready"
 			fmt.Println(msg)
-		case <-time.After(5 * time.Minute):
+		case <-time.After(1 * time.Minute):
 			defer close(stopChannel)
 			msg := "ExternalSecret is not ready"
 			assert.Fail(s.T(), msg)

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -171,6 +171,7 @@ func (s *ComponentSuite) TestBasic() {
 			msg := "ExternalSecret is ready"
 			fmt.Println(msg)
 		case <-time.After(5 * time.Minute):
+			defer close(stopChannel)
 			msg := "ExternalSecret is not ready"
 			assert.Fail(s.T(), msg)
 	}

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -170,7 +170,7 @@ func (s *ComponentSuite) TestBasic() {
 		case <-stopChannel:
 			msg := "ExternalSecret is ready"
 			fmt.Println(msg)
-		case <-time.After(1 * time.Minute):
+		case <-time.After(5 * time.Minute):
 			msg := "ExternalSecret is not ready"
 			assert.Fail(s.T(), msg)
 	}

--- a/test/fixtures/stacks/orgs/default/test/tests.yaml
+++ b/test/fixtures/stacks/orgs/default/test/tests.yaml
@@ -2,8 +2,5 @@ import:
   - orgs/default/test/_defaults
   - catalog/vpc
   - catalog/eks-cluster
-  - catalog/dns-primary
-  - catalog/dns-delegated
-  - catalog/eks-alb-controller
   - catalog/usecase/basic
   - catalog/usecase/disabled


### PR DESCRIPTION
# What
* [ ] Add `basic` component test
* [ ] Add `disabled` component test
* [ ] Test component drifting
* [ ] Add any additional use case tests


# Why
* Test basic component features
* Verify that the component does not create any resources when input `enabled: false` set
* Verify that the component does not drift on a second run with the same inputs
* Add test for any additional than basic use cases for the component

# References
* [Component test writing guide](https://docs.cloudposse.com/community/contribute/component-testing/)
* [List of component tests are done](https://github.com/orgs/cloudposse-terraform-components/projects/1/views/3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Streamlined configuration management by removing redundant dependency imports, simplifying the setup process.
- **Bug Fixes**
	- Increased timeout duration for waiting on the readiness of `ExternalSecret` resources, enhancing reliability in tests.
	- Improved test flow and clarity by adding comments and ensuring proper resource checks during deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->