### PR TITLE
Fix: use v1 externalsecrets clusterstore if available

### DIFF
--- a/src/charts/external-ssm-secrets/templates/ssm-secret-store.yaml
+++ b/src/charts/external-ssm-secrets/templates/ssm-secret-store.yaml
@@ -1,4 +1,4 @@
-{{ if $.Capabilities.APIVersions.Has "external-secrets.io/v1/ClusterSecretStore" -}}
+{{ if .Capabilities.APIVersions.Has "external-secrets.io/v1/ClusterSecretStore" -}}
 apiVersion: external-secrets.io/v1
 {{- else -}}
 apiVersion: external-secrets.io/v1beta1

--- a/src/charts/external-ssm-secrets/templates/ssm-secret-store.yaml
+++ b/src/charts/external-ssm-secrets/templates/ssm-secret-store.yaml
@@ -1,4 +1,8 @@
+{{ if $.Capabilities.APIVersions.Has "external-secrets.io/v1/ClusterSecretStore" -}}
+apiVersion: external-secrets.io/v1
+{{- else -}}
 apiVersion: external-secrets.io/v1beta1
+{{- end }}
 kind: ClusterSecretStore
 metadata:
   name: "secret-store-parameter-store"

--- a/src/main.tf
+++ b/src/main.tf
@@ -129,14 +129,6 @@ module "external_ssm_secrets" {
   values = compact([
     yamlencode({
       region                = var.region,
-      parameter_store_paths = var.parameter_store_paths
-      resources             = var.resources
-      serviceAccount = {
-        name = module.this.name
-      }
-      rbac = {
-        create = var.rbac_enabled
-      }
     })
   ])
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -128,7 +128,7 @@ module "external_ssm_secrets" {
 
   values = compact([
     yamlencode({
-      region                = var.region,
+      region = var.region
     })
   ])
 


### PR DESCRIPTION
## what
* Allow both v1 and v1beta of ClusterSecretStore
* Removal unused values

## why
* v1beta has been deprecated and does not work in ESO v.0.17.0+ (latest is 0.18.0)
* Having unused values passed through the helm chart is confusing

## references
* https://github.com/external-secrets/external-secrets/releases/tag/helm-chart-0.17.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The system now automatically selects the appropriate API version for secret store resources based on your Kubernetes cluster's supported versions.

* **Chores**
  * Simplified configuration by removing unused parameters from the module setup, reducing the amount of configuration required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->