### PR TITLE
feat(ssm-secrets): add support for extra config options

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -128,7 +128,7 @@ module "external_ssm_secrets" {
 
   values = compact([
     yamlencode({
-      region                = var.region,
+      region                = var.region
       parameter_store_paths = var.parameter_store_paths
       resources             = var.resources
       serviceAccount = {

--- a/src/main.tf
+++ b/src/main.tf
@@ -128,7 +128,15 @@ module "external_ssm_secrets" {
 
   values = compact([
     yamlencode({
-      region = var.region
+      region                = var.region,
+      parameter_store_paths = var.parameter_store_paths
+      resources             = var.resources
+      serviceAccount = {
+        name = module.this.name
+      }
+      rbac = {
+        create = var.rbac_enabled
+      }
     })
   ])
 


### PR DESCRIPTION
## what

* Added support for specifying `parameter_store_paths` and `resources` in the values passed to the `external_ssm_secrets` module, enabling more granular control over which secrets and resources are managed.
* Introduced a `serviceAccount` configuration that sets the service account name based on `module.this.name`, improving service account management.
* Added an `rbac` configuration block with a `create` flag controlled by `var.rbac_enabled`, allowing for optional RBAC resource creation.

## why

- This updates the configuration for the `external_ssm_secrets` module to support additional customization and RBAC (Role-Based Access Control) options. The main changes expand the set of values passed to the module, allowing for more flexible and secure integration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure multiple Parameter Store paths for external secrets.
  * Add resource requests/limits configuration for pods.
  * Specify custom ServiceAccount names and toggle RBAC creation.
  * Maintains existing region configuration.

* **Chores**
  * Updated chart/values structure to support the new configuration options without changing existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->