### PR TITLE
Add EKS and account map variables to remote-state.tf

### DIFF
--- a/src/providers.tf
+++ b/src/providers.tf
@@ -1,3 +1,30 @@
+// These variables aren't used by default - but if you use the account-map-less terraform provider we need these defined.
+variable "account_map_enabled" {
+  type        = bool
+  description = "Enable the account map component"
+  default     = false
+}
+
+variable "account_map" {
+  type = object({
+    full_account_map              = map(string)
+    audit_account_account_name    = optional(string, "")
+    root_account_account_name     = optional(string, "")
+    identity_account_account_name = optional(string, "")
+    aws_partition                 = optional(string, "aws")
+    iam_role_arn_templates        = optional(map(string), {})
+  })
+  description = "Map of account names (tenant-stage format) to account IDs. Used to verify we're targeting the correct AWS account. Optional attributes support component-specific functionality (e.g., audit_account_account_name for cloudtrail, root_account_account_name for aws-sso)."
+  default = {
+    full_account_map              = {}
+    audit_account_account_name    = ""
+    root_account_account_name     = ""
+    identity_account_account_name = ""
+    aws_partition                 = "aws"
+    iam_role_arn_templates        = {}
+  }
+}
+
 provider "aws" {
   region = var.region
 

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -44,6 +44,9 @@ variable "account_map_stage_name" {
   description = "The name of the stage where account-map is deployed. Only used when account_map_enabled is true."
 }
 
+locals {
+  account_map_enabled = var.enabled && var.account_map_enabled
+}
 module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "2.0.0"
@@ -52,7 +55,7 @@ module "account_map" {
   environment = var.account_map_environment_name
   stage       = var.account_map_stage_name
 
-  bypass = !var.account_map_enabled
+  bypass = !local.account_map_enabled
 
   defaults = {
     full_account_map = var.account_map.full_account_map

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -1,10 +1,47 @@
+variable "eks" {
+  type = object({
+    eks_cluster_id                   = optional(string, null)
+    eks_cluster_arn                  = optional(string, null)
+    eks_cluster_endpoint             = optional(string, null)
+    eks_cluster_certificate_authority_data = optional(string, null)
+    eks_cluster_identity_oidc_issuer = optional(string, null)
+    karpenter_iam_role_arn           = optional(string, null)
+  })
+  description = "EKS cluster outputs. When set, bypasses remote-state lookup of eks/cluster."
+  default     = null
+  nullable    = true
+}
+
 module "eks" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
   component = var.eks_component_name
 
+  bypass = var.eks != null
+
+  defaults = {
+    eks_cluster_id                   = try(var.eks.eks_cluster_id, null)
+    eks_cluster_arn                  = try(var.eks.eks_cluster_arn, null)
+    eks_cluster_endpoint             = try(var.eks.eks_cluster_endpoint, null)
+    eks_cluster_certificate_authority_data = try(var.eks.eks_cluster_certificate_authority_data, null)
+    eks_cluster_identity_oidc_issuer = try(var.eks.eks_cluster_identity_oidc_issuer, null)
+    karpenter_iam_role_arn           = try(var.eks.karpenter_iam_role_arn, null)
+  }
+
   context = module.this.context
+}
+
+variable "account_map_environment_name" {
+  type        = string
+  default     = "gbl"
+  description = "The name of the environment where account-map is deployed. Only used when account_map_enabled is true."
+}
+
+variable "account_map_stage_name" {
+  type        = string
+  default     = "root"
+  description = "The name of the stage where account-map is deployed. Only used when account_map_enabled is true."
 }
 
 module "account_map" {
@@ -12,9 +49,15 @@ module "account_map" {
   version = "1.8.0"
 
   component   = "account-map"
-  tenant      = module.iam_roles.global_tenant_name
-  environment = module.iam_roles.global_environment_name
-  stage       = module.iam_roles.global_stage_name
+  environment = var.account_map_environment_name
+  stage       = var.account_map_stage_name
+
+  bypass = !var.account_map_enabled
+
+  defaults = {
+    full_account_map = var.account_map.full_account_map
+  }
 
   context = module.this.context
 }
+

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -46,7 +46,7 @@ variable "account_map_stage_name" {
 
 module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component   = "account-map"
   environment = var.account_map_environment_name

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -1,11 +1,11 @@
 variable "eks" {
   type = object({
-    eks_cluster_id                   = optional(string, null)
-    eks_cluster_arn                  = optional(string, null)
-    eks_cluster_endpoint             = optional(string, null)
+    eks_cluster_id                         = optional(string, null)
+    eks_cluster_arn                        = optional(string, null)
+    eks_cluster_endpoint                   = optional(string, null)
     eks_cluster_certificate_authority_data = optional(string, null)
-    eks_cluster_identity_oidc_issuer = optional(string, null)
-    karpenter_iam_role_arn           = optional(string, null)
+    eks_cluster_identity_oidc_issuer       = optional(string, null)
+    karpenter_iam_role_arn                 = optional(string, null)
   })
   description = "EKS cluster outputs. When set, bypasses remote-state lookup of eks/cluster."
   default     = null
@@ -21,12 +21,12 @@ module "eks" {
   bypass = var.eks != null
 
   defaults = {
-    eks_cluster_id                   = try(var.eks.eks_cluster_id, null)
-    eks_cluster_arn                  = try(var.eks.eks_cluster_arn, null)
-    eks_cluster_endpoint             = try(var.eks.eks_cluster_endpoint, null)
+    eks_cluster_id                         = try(var.eks.eks_cluster_id, null)
+    eks_cluster_arn                        = try(var.eks.eks_cluster_arn, null)
+    eks_cluster_endpoint                   = try(var.eks.eks_cluster_endpoint, null)
     eks_cluster_certificate_authority_data = try(var.eks.eks_cluster_certificate_authority_data, null)
-    eks_cluster_identity_oidc_issuer = try(var.eks.eks_cluster_identity_oidc_issuer, null)
-    karpenter_iam_role_arn           = try(var.eks.karpenter_iam_role_arn, null)
+    eks_cluster_identity_oidc_issuer       = try(var.eks.eks_cluster_identity_oidc_issuer, null)
+    karpenter_iam_role_arn                 = try(var.eks.karpenter_iam_role_arn, null)
   }
 
   context = module.this.context

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -14,7 +14,7 @@ variable "eks" {
 
 module "eks" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component = var.eks_component_name
 

--- a/test/fixtures/stacks/catalog/account-map.yaml
+++ b/test/fixtures/stacks/catalog/account-map.yaml
@@ -8,17 +8,17 @@ components:
         environment: gbl
         stage: root
 
-#      This remote state is only for Cloud Posse internal use.
-#      It references the Cloud Posse test organizations actual infrastructure.
-#      remote_state_backend:
-#        s3:
-#          bucket: cptest-core-ue2-root-tfstate-core
-#          dynamodb_table: cptest-core-ue2-root-tfstate-core-lock
-#          role_arn: arn:aws:iam::822777368227:role/cptest-core-gbl-root-tfstate-core-ro
-#          encrypt: true
-#          key: terraform.tfstate
-#          acl: bucket-owner-full-control
-#          region: us-east-2
+      #      This remote state is only for Cloud Posse internal use.
+      #      It references the Cloud Posse test organizations actual infrastructure.
+      #      remote_state_backend:
+      #        s3:
+      #          bucket: cptest-core-ue2-root-tfstate-core
+      #          dynamodb_table: cptest-core-ue2-root-tfstate-core-lock
+      #          role_arn: arn:aws:iam::822777368227:role/cptest-core-gbl-root-tfstate-core-ro
+      #          encrypt: true
+      #          key: terraform.tfstate
+      #          acl: bucket-owner-full-control
+      #          region: us-east-2
 
       remote_state_backend_type: static
       remote_state_backend:

--- a/test/fixtures/stacks/catalog/usecase/basic.yaml
+++ b/test/fixtures/stacks/catalog/usecase/basic.yaml
@@ -4,6 +4,10 @@ components:
       metadata:
         component: eks/external-secrets-operator
       vars:
+        account_map_enabled: false
+        account_map:
+          full_account_map:
+            default-test: '{{ getenv "TEST_ACCOUNT_ID" | default "<TEST_ACCOUNT_ID>" }}'
         enabled: true
         kube_exec_auth_role_arn_enabled: false
         dns_gbl_delegated_environment_name: ue2

--- a/test/fixtures/stacks/catalog/usecase/disabled.yaml
+++ b/test/fixtures/stacks/catalog/usecase/disabled.yaml
@@ -5,6 +5,10 @@ components:
         component: eks/external-secrets-operator
       vars:
         enabled: false
+        account_map_enabled: false
+        account_map:
+          full_account_map:
+            default-test: '{{ getenv "TEST_ACCOUNT_ID" | default "<TEST_ACCOUNT_ID>" }}'
         kube_exec_auth_role_arn_enabled: false
         dns_gbl_delegated_environment_name: ue2
         dns_gbl_primary_environment_name: ue2

--- a/test/fixtures/stacks/orgs/default/test/_defaults.yaml
+++ b/test/fixtures/stacks/orgs/default/test/_defaults.yaml
@@ -63,4 +63,4 @@ components:
           identity_account_account_name: default-test
           root_account_account_name: default-test
           terraform_roles:
-            default-test: ''
+            default-test: ""

--- a/test/fixtures/vendor.yaml
+++ b/test/fixtures/vendor.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   sources:
     - component: "account-map"
-      source: github.com/cloudposse/terraform-aws-components.git//modules/account-map?ref={{.Version}}
+      source: github.com/cloudposse-terraform-components/aws-account-map.git//src?ref={{.Version}}
       version: v1.537.2
       targets:
         - "components/terraform/account-map"

--- a/test/fixtures/vendor.yaml
+++ b/test/fixtures/vendor.yaml
@@ -7,7 +7,7 @@ spec:
   sources:
     - component: "account-map"
       source: github.com/cloudposse/terraform-aws-components.git//modules/account-map?ref={{.Version}}
-      version: 1.520.0
+      version: v1.537.2
       targets:
         - "components/terraform/account-map"
       included_paths:
@@ -19,7 +19,7 @@ spec:
 
     - component: "eks/cluster"
       source: github.com/cloudposse-terraform-components/aws-eks-cluster.git//src?ref={{.Version}}
-      version: v1.535.1
+      version: v1.540.3
       targets:
         - "components/terraform/eks/cluster"
       included_paths:
@@ -31,7 +31,7 @@ spec:
 
     - component: "vpc"
       source: github.com/cloudposse-terraform-components/aws-vpc.git//src?ref={{.Version}}
-      version: v1.536.0
+      version: v2.1.2
       targets:
         - "components/terraform/vpc"
       included_paths:


### PR DESCRIPTION
This pull request updates the `src/remote-state.tf` file to improve flexibility in how remote state is handled for both the EKS and account map modules. The main changes allow users to bypass remote state lookups by providing values directly, and make the configuration of environment and stage names for the account map more customizable.

Key changes:

**EKS Remote State Flexibility:**
* Added a new `eks` variable, allowing direct input of EKS cluster outputs to bypass remote-state lookup when set. The `bypass` and `defaults` parameters in the `eks` module are updated accordingly.

**Account Map Configuration:**
* Introduced `account_map_environment_name` and `account_map_stage_name` variables to specify the environment and stage for the account map, replacing previous hardcoded values.
* Updated the `account_map` module to support bypassing remote state lookup when `account_map_enabled` is false, and to accept default values for the full account map.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allow supplying EKS/Karpenter outputs directly and configure environment/stage for account mapping; added a toggle to enable/disable account map usage.

* **Refactor**
  * Remote-state lookups can be bypassed when inputs are provided, using supplied defaults instead.

* **Chores**
  * Bumped vendored component pins for account-map, EKS cluster, and VPC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->